### PR TITLE
Fix #emit in unused functions

### DIFF
--- a/source/compiler/sc2.c
+++ b/source/compiler/sc2.c
@@ -1330,7 +1330,8 @@ static int command(void)
               /* mark function as "used" */
               /* do NOT mark it as written as that has a different meaning for
                * functions (marks them as "should return a value") */
-              markusage(sym,uREAD);
+              if (sc_status!=statSKIP)
+                markusage(sym,uREAD);
             } else {
               outval(sym->addr,FALSE);
               /* mark symbol as "used", unknown whether for read or write */


### PR DESCRIPTION
Hello!

The crash only happens when the parser skips the initialization of functions with SYSREQ. I.e. if we don't call  the functions with `#emit SYSREQ`, the compiler crashs. BUT it doesn't work with public-functions.

Crash:
```pawn
stock somefunc()
{
	#emit push.c 100
	#emit push.c 4

	#emit sysreq.c random

	#emit stack 8
	#emit retn
	return 0;
}

main()
{
// don't call somefunc.
}
```

Ok:
```pawn
stock somefunc()
{
	#emit push.c 100
	#emit push.c 4

	#emit sysreq.c random

	#emit stack 8
	#emit retn
	return 0;
}

main()
{
	somefunc();  // call it.
}
```